### PR TITLE
[Bug]: fixing the underlined text in SideNav

### DIFF
--- a/src/components/SideNav/SideNav.module.css
+++ b/src/components/SideNav/SideNav.module.css
@@ -45,7 +45,7 @@
   padding: 10px 0px 10px 0px;
   border-right: solid orange 5px;
   font-weight: 300;
-
+  text-decoration: none;
 }
 
 .sideTabs:hover {


### PR DESCRIPTION
## Changes
1. Modded  SideNav CSS file to remove text-decoration on side tabs
<img width="1277" alt="Screen Shot 2025-01-29 at 9 20 19 AM" src="https://github.com/user-attachments/assets/80dd3866-2269-4900-8a60-2ba1e083d13f" />

Closes #4 
