### PR TITLE
Click drag modal date bug

### DIFF
--- a/src/Components/Forms/CreateEventForm.jsx
+++ b/src/Components/Forms/CreateEventForm.jsx
@@ -29,7 +29,7 @@ const CreateEventForm = ({
 
   const [reservationData, setReservationData] = React.useState({
     name: 'New Event',
-    date: new Date(),
+    date: selectedSlot?.start ?? new Date(),
     start: selectedSlot?.start ?? roundedStart,
     end: selectedSlot?.end ?? addMinutes(roundedStart, 15),
     resourceId: calendarId ?? selectedSlot?.resourceId ?? '',


### PR DESCRIPTION
## Changes
1. Changed creatEventForm.jsx from always setting the Date for the modal to the current date to when the user creates an event through selecting on the calendar to set the date to the start date/time of the selected box.

## Purpose

More intuitive UX if a user wants to schedule ahead on another date, to automatically populate the date to the calendar day where the user is clicking and dragging. 

Before, dates did not match: 
<img width="1509" alt="Screenshot 2025-06-03 at 5 06 16 PM" src="https://github.com/user-attachments/assets/6c6a1d04-5bc6-4d17-814b-a51b8521aee2" />


Now all the dates match:
<img width="1508" alt="Screenshot 2025-06-03 at 5 03 56 PM" src="https://github.com/user-attachments/assets/86f9825d-7ff1-46fe-a467-8fdcf0b1a2ee" />

