### PR TITLE
fix(People API): added edge case of null people API

### DIFF
--- a/src/api/events/getEvents.js
+++ b/src/api/events/getEvents.js
@@ -1,7 +1,7 @@
 import { gapi } from 'gapi-script';
 import { addMonths, startOfToday } from 'date-fns';
 
-const getEvents = async (calendarId = 'primary', userInfo, people) => {
+const getEvents = async (calendarId = 'primary', userInfo, people = []) => {
   try {
     //Make the request to Google Calendar with specified parameters
     const response = await gapi.client.calendar.events.list({
@@ -45,10 +45,10 @@ const getEvents = async (calendarId = 'primary', userInfo, people) => {
       }
       const attendeeNames = event.attendees
         ? event.attendees
-            .filter((a) => !a.resource)
-            .map(
-              (a) => peopleMap[a.email] || (a.email?.split('@')[0] ?? 'Unknown')
-            )
+          .filter((a) => !a.resource)
+          .map(
+            (a) => peopleMap[a.email] || (a.email?.split('@')[0] ?? 'Unknown')
+          )
         : [];
 
       const isOrganizer = event.organizer?.email === userInfo.email;

--- a/src/api/people/getPeople.js
+++ b/src/api/people/getPeople.js
@@ -19,6 +19,7 @@ const getPeople = async () => {
     return simplifiedPeople;
   } catch (error) {
     console.error('Error fetching people:', error);
+    return [];
   }
 };
 


### PR DESCRIPTION
## Changes
1. getEvents.js
2. getPeople.js

## Purpose
1. if the people API is returning an error, return [], so that it doesn't completely freeze on the output of the API

## Approach
1. Looking for what People API is returning.
2. Adding a case that makes sure null response from People is accounted for.

## To Do After
1. Check in with IT as the problem seems to be a restriction changes in the google cloud console by IT.
